### PR TITLE
Add Dependabot config for Maven and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dev-deps:
+        dependency-type: "development"
+        update-types:
+          - "minor"
+          - "patch"
+      prod-deps:
+        dependency-type: "production"
+        update-types:
+          - "minor"
+          - "patch"
+    assignees:
+      - "sleberknight"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions-deps:
+        patterns:
+          - "*"
+    assignees:
+      - "sleberknight"
+    commit-message:
+      prefix: "chore(deps)"


### PR DESCRIPTION
Add Dependabot configuration to keep Maven dependencies and GitHub Actions up to date on a weekly schedule.