### PR TITLE
Fix Maven Central search URL and query syntax

### DIFF
--- a/src/main/java/mvn/depgenerator/DependencyGenerator.java
+++ b/src/main/java/mvn/depgenerator/DependencyGenerator.java
@@ -1,10 +1,10 @@
 package mvn.depgenerator;
 
-import java.util.List;
-import java.util.Optional;
-
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
+
+import java.util.List;
+import java.util.Optional;
 
 public class DependencyGenerator {
 
@@ -24,7 +24,7 @@ public class DependencyGenerator {
             System.out.printf("Usage: java %s <groupId> [version]%n", className);
             System.out.println();
             System.out.printf("Example with group:%njava %s io.dropwizard%n%n", className);
-            System.out.printf("Example with group and version:%njava %s io.dropwizard 0.9.2%n", className);
+            System.out.printf("Example with group and version:%njava %s io.dropwizard 5.0.2%n", className);
             System.exit(1);
         }
 

--- a/src/main/java/mvn/depgenerator/DependencyGenerator.java
+++ b/src/main/java/mvn/depgenerator/DependencyGenerator.java
@@ -11,7 +11,7 @@ public class DependencyGenerator {
     private static final String LINE_SEPARATOR = System.lineSeparator();
     private static final String SEPARATOR = String.format("%s%s", LINE_SEPARATOR, LINE_SEPARATOR);
 
-    public static void main(String[] args) {
+    void main(String[] args) {
         String group = null;
         Optional<String> version = Optional.empty();
         if (args.length == 1) {

--- a/src/main/java/mvn/depgenerator/DependencySearcher.java
+++ b/src/main/java/mvn/depgenerator/DependencySearcher.java
@@ -16,7 +16,7 @@ import java.util.concurrent.TimeUnit;
 public class DependencySearcher {
 
     private static final String LINE_SEPARATOR = System.lineSeparator();
-    private static final String MAVEN_SEARCH_URL = "https://search.maven.org";
+    private static final String MAVEN_SEARCH_URL = "https://central.sonatype.com";
     private static final String MAVEN_SEARCH_PATH = "solrsearch/select";
     private static final int ROWS = 1000;
     private static final String TYPE = "json";
@@ -102,11 +102,11 @@ public class DependencySearcher {
     }
 
     private static String buildSolrQuery(String group, String version) {
-        return String.format("g:\"%s\" AND v:\"%s\"", group, version);
+        return String.format("g:%s AND v:%s", group, version);
     }
 
     private static String buildSolrQuery(String group) {
-        return String.format("g:\"%s\"", group);
+        return String.format("g:%s", group);
     }
 
 }

--- a/src/main/java/mvn/depgenerator/MvnDependency.java
+++ b/src/main/java/mvn/depgenerator/MvnDependency.java
@@ -1,16 +1,16 @@
 package mvn.depgenerator;
 
-import com.google.common.collect.ImmutableList;
+import static mvn.depgenerator.util.MapsHelper.immutableStringList;
+import static mvn.depgenerator.util.MapsHelper.longValue;
+import static mvn.depgenerator.util.MapsHelper.string;
+
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.List;
 import java.util.Map;
-
-import static mvn.depgenerator.util.MapsHelper.immutableStringList;
-import static mvn.depgenerator.util.MapsHelper.longValue;
-import static mvn.depgenerator.util.MapsHelper.string;
 
 /**
  * Represent structure for searches that include the group and version number (and optionally artifact).
@@ -58,18 +58,20 @@ public class MvnDependency {
     private final String version;
     private final String packaging;
     private final Long timestamp;
-    private final ImmutableList<String> tags;
-    private final ImmutableList<String> ec;
+    private final List<String> tags;
+    private final List<String> ec;
 
     public String toXml() {
-        return String.format("<dependency>\n"
-                        + "  <groupId>%s</groupId>\n"
-                        + "  <artifactId>%s</artifactId>\n"
-                        + "  <version>%s</version>\n"
-                        + "  <type>%s</type>\n"
-                        + "</dependency>\n",
-                group, artifact, version, packaging
-        );
+        var format = """
+                <dependency>
+                    <groupId>%s</groupId>
+                    <artifactId>%s</artifactId>
+                    <version>%s</version>
+                    <type>%s</type>
+                </dependency>
+                """;
+
+        return format.formatted(group, artifact, version, packaging);
     }
 
     public static MvnDependency from(Map<String, Object> doc) {
@@ -93,7 +95,7 @@ public class MvnDependency {
                 .version(groupDependency.getLatestVersion())
                 .packaging(groupDependency.getPackaging())
                 .timestamp(groupDependency.getTimestamp())
-                .tags(ImmutableList.of())
+                .tags(List.of())
                 .ec(groupDependency.getEc())
                 .build();
     }

--- a/src/main/java/mvn/depgenerator/MvnGroupDependency.java
+++ b/src/main/java/mvn/depgenerator/MvnGroupDependency.java
@@ -1,17 +1,17 @@
 package mvn.depgenerator;
 
-import com.google.common.collect.ImmutableList;
+import static mvn.depgenerator.util.MapsHelper.immutableStringList;
+import static mvn.depgenerator.util.MapsHelper.integerValue;
+import static mvn.depgenerator.util.MapsHelper.longValue;
+import static mvn.depgenerator.util.MapsHelper.string;
+
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
+import java.util.List;
 import java.util.Map;
-
-import static mvn.depgenerator.util.MapsHelper.immutableStringList;
-import static mvn.depgenerator.util.MapsHelper.integerValue;
-import static mvn.depgenerator.util.MapsHelper.longValue;
-import static mvn.depgenerator.util.MapsHelper.string;
 
 /**
  * Represent structure for searches that include only the group and optionally artifact (no version number).
@@ -63,8 +63,8 @@ public class MvnGroupDependency {
     private final String packaging;
     private final Long timestamp;
     private final Integer versionCount;
-    private final ImmutableList<String> text;
-    private final ImmutableList<String> ec;
+    private final List<String> text;
+    private final List<String> ec;
 
     public static MvnGroupDependency from(Map<String, Object> doc) {
         return MvnGroupDependency.builder()

--- a/src/main/java/mvn/depgenerator/util/MapsHelper.java
+++ b/src/main/java/mvn/depgenerator/util/MapsHelper.java
@@ -1,10 +1,13 @@
 package mvn.depgenerator.util;
 
-import com.google.common.collect.ImmutableList;
+import static java.util.Objects.isNull;
+
+import lombok.experimental.UtilityClass;
 
 import java.util.List;
 import java.util.Map;
 
+@UtilityClass
 public final class MapsHelper {
 
     public static String string(Map<String, Object> map, String key) {
@@ -20,8 +23,12 @@ public final class MapsHelper {
     }
 
     @SuppressWarnings("unchecked")
-    public static ImmutableList<String> immutableStringList(Map<String, Object> map, String key) {
+    public static List<String> immutableStringList(Map<String, Object> map, String key) {
+        if (isNull(map.get(key))) {
+            return List.of();
+        }
+
         List<String> strings = (List<String>) map.get(key);
-        return ImmutableList.copyOf(strings);
+        return List.copyOf(strings);
     }
 }


### PR DESCRIPTION
The Solr search backend at search.maven.org has been decommissioned as part of the Maven Central migration to the new Central Portal. The same Solr API is now hosted at central.sonatype.com, but with one difference: the quoted field syntax (g:"value") is not supported -- values must be unquoted (g:value).