### PR TITLE
Replace Jersey client with JDK 11 HttpClient

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,6 @@
         <lombok.version>1.18.46</lombok.version>
         <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <guava.version>33.6.0-jre</guava.version>
-        <jersey-client.version>3.1.12</jersey-client.version>
         <jackson-databind.version>2.22.0</jackson-databind.version>
     </properties>
 
@@ -26,12 +25,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <version>${jersey-client.version}</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/mvn/depgenerator/DependencySearcher.java
+++ b/src/main/java/mvn/depgenerator/DependencySearcher.java
@@ -3,28 +3,28 @@ package mvn.depgenerator;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 
-import jakarta.ws.rs.client.Client;
-import jakarta.ws.rs.client.ClientBuilder;
-import jakarta.ws.rs.client.WebTarget;
-import jakarta.ws.rs.core.Response;
 import mvn.depgenerator.util.Json;
 
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 public class DependencySearcher {
 
     private static final String LINE_SEPARATOR = System.lineSeparator();
-    private static final String MAVEN_SEARCH_URL = "https://central.sonatype.com";
-    private static final String MAVEN_SEARCH_PATH = "solrsearch/select";
+    private static final String MAVEN_SEARCH_HOST = "central.sonatype.com";
+    private static final String MAVEN_SEARCH_PATH = "/solrsearch/select";
     private static final int ROWS = 1000;
     private static final String TYPE = "json";
 
-    private static final Client CLIENT = ClientBuilder
-            .newBuilder()
-            .connectTimeout(5, TimeUnit.SECONDS)
-            .readTimeout(30, TimeUnit.SECONDS)
+    private static final HttpClient CLIENT = HttpClient.newBuilder()
+            .connectTimeout(Duration.ofSeconds(5))
             .build();
 
     public static void close() {
@@ -32,8 +32,7 @@ public class DependencySearcher {
     }
 
     public static List<MvnDependency> getMvnDependencies(String group, String version) {
-        WebTarget baseTarget = getBaseTarget();
-        ResponseInfo responseInfo = search(baseTarget, group, version);
+        ResponseInfo responseInfo = search(buildSolrQuery(group, version));
         validateResponse(responseInfo);
 
         Map<String, Object> responseMap = Json.toMap(responseInfo.responseText);
@@ -43,8 +42,7 @@ public class DependencySearcher {
     }
 
     public static List<MvnGroupDependency> getMvnDependencies(String group) {
-        WebTarget baseTarget = getBaseTarget();
-        ResponseInfo responseInfo = search(baseTarget, group);
+        ResponseInfo responseInfo = search(buildSolrQuery(group));
         validateResponse(responseInfo);
 
         Map<String, Object> responseMap = Json.toMap(responseInfo.responseText);
@@ -60,45 +58,29 @@ public class DependencySearcher {
     }
 
     private static void validateResponse(ResponseInfo responseInfo) {
-        if (responseInfo.statusCode != Response.Status.OK.getStatusCode()) {
+        if (responseInfo.statusCode != 200) {
             String error = String.format("%s (status code: %s)", responseInfo.responseText, responseInfo.statusCode);
             throw new RuntimeException(error);
         }
     }
 
-    private static WebTarget getBaseTarget() {
-        return CLIENT.target(MAVEN_SEARCH_URL).path(MAVEN_SEARCH_PATH);
-    }
-
-    private static ResponseInfo search(WebTarget baseTarget, String group) {
-        WebTarget target = buildTarget(baseTarget, group);
-        return search(target);
-    }
-
-    private static ResponseInfo search(WebTarget baseTarget, String group, String version) {
-        WebTarget target = buildTarget(baseTarget, group, version);
-        return search(target);
-    }
-
-    private static ResponseInfo search(WebTarget target) {
-        Response response = target.request().get();
-        return new ResponseInfo(response.getStatusInfo(), response.readEntity(String.class));
-    }
-
-    private static WebTarget buildTarget(WebTarget baseTarget, String group, String version) {
-        String solrQuery = buildSolrQuery(group, version);
-        return buildWebTarget(baseTarget, solrQuery);
-    }
-
-    private static WebTarget buildTarget(WebTarget baseTarget, String group) {
-        String solrQuery = buildSolrQuery(group);
-        return buildWebTarget(baseTarget, solrQuery);
-    }
-
-    private static WebTarget buildWebTarget(WebTarget baseTarget, String solrQuery) {
-        return baseTarget.queryParam("q", solrQuery)
-                .queryParam("rows", ROWS)
-                .queryParam("wt", TYPE);
+    private static ResponseInfo search(String solrQuery) {
+        try {
+            String queryString = String.format("q=%s&rows=%d&wt=%s", solrQuery, ROWS, TYPE);
+            URI uri = new URI("https", MAVEN_SEARCH_HOST, MAVEN_SEARCH_PATH, queryString, null);
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(uri)
+                    .timeout(Duration.ofSeconds(30))
+                    .GET()
+                    .build();
+            HttpResponse<String> response = CLIENT.send(request, HttpResponse.BodyHandlers.ofString());
+            return new ResponseInfo(response.statusCode(), response.body());
+        } catch (URISyntaxException | IOException e) {
+            throw new RuntimeException("Maven Central search failed", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Maven Central search was interrupted", e);
+        }
     }
 
     private static String buildSolrQuery(String group, String version) {

--- a/src/main/java/mvn/depgenerator/ResponseInfo.java
+++ b/src/main/java/mvn/depgenerator/ResponseInfo.java
@@ -1,16 +1,12 @@
 package mvn.depgenerator;
 
-import jakarta.ws.rs.core.Response;
-
 public class ResponseInfo {
 
     final int statusCode;
-    final Response.StatusType status;
     final String responseText;
 
-    public ResponseInfo(Response.StatusType status, String responseText) {
-        this.statusCode = status.getStatusCode();
-        this.status = status;
+    public ResponseInfo(int statusCode, String responseText) {
+        this.statusCode = statusCode;
         this.responseText = responseText;
     }
 }


### PR DESCRIPTION
Removes the jersey-client dependency and replaces it with java.net.http.HttpClient (available since JDK 11). This eliminates the HK2 injection warning and the jakarta.activation warning that appeared at startup.

ResponseInfo is simplified to hold a plain int status code and response body string, with no dependency on jakarta.ws.rs types.