### PR TITLE
Upgrade Jackson 2.x to 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,13 +15,13 @@
         <java.version>25</java.version>
         <lombok.version>1.18.46</lombok.version>
         <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
-        <jackson-databind.version>2.22.0</jackson-databind.version>
+        <jackson-databind.version>3.1.2</jackson-databind.version>
     </properties>
 
     <dependencies>
 
         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <version>${jackson-databind.version}</version>
         </dependency>

--- a/src/main/java/mvn/depgenerator/util/Json.java
+++ b/src/main/java/mvn/depgenerator/util/Json.java
@@ -1,10 +1,8 @@
 package mvn.depgenerator.util;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
 
-import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.util.Map;
 
 public final class Json {
@@ -12,12 +10,7 @@ public final class Json {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
     public static Map<String, Object> toMap(String json) {
-        try {
-            return MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {
-            });
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        return MAPPER.readValue(json, new TypeReference<Map<String, Object>>() {});
     }
 
 }


### PR DESCRIPTION
Upgrades jackson-databind from 2.22.0 to 3.1.2.

Jackson 3.x ships under a new Maven groupId (tools.jackson.core instead of com.fasterxml.jackson.core) and a new Java package namespace (tools.jackson instead of com.fasterxml.jackson). ObjectMapper.readValue() now throws unchecked JacksonException rather than checked IOException, so the try/catch in Json.toMap() is removed.